### PR TITLE
3. Sequential Logic

### DIFF
--- a/projects/03/README.md
+++ b/projects/03/README.md
@@ -1,0 +1,7 @@
+# projects 03
+
+```sh
+# Install Java
+# $ chmod +x ./tools/HardwareSimulator.sh
+$ ./tools/HardwareSimulator.sh
+```

--- a/projects/03/a/Bit.hdl
+++ b/projects/03/a/Bit.hdl
@@ -14,7 +14,7 @@ CHIP Bit {
     OUT out;
 
     PARTS:
-    // load=1 なら読み込み（read）、load=0 なら書き込み（write）
+    // load=0 なら読み込み（read）、load=1 なら書き込み（write）
     Mux(a=feedback, b=in, sel=load, out=muxout);
     DFF(in=muxout, out=out, out=feedback);
 }

--- a/projects/03/a/Bit.hdl
+++ b/projects/03/a/Bit.hdl
@@ -14,5 +14,7 @@ CHIP Bit {
     OUT out;
 
     PARTS:
-    // Put your code here:
+    // load=1 なら読み込み（read）、load=0 なら書き込み（write）
+    Mux(a=feedback, b=in, sel=load, out=muxout);
+    DFF(in=muxout, out=out, out=feedback);
 }

--- a/projects/03/a/RAM64.hdl
+++ b/projects/03/a/RAM64.hdl
@@ -5,8 +5,8 @@
 
 /**
  * Memory of 64 registers, each 16 bit-wide. Out holds the value
- * stored at the memory location specified by address. If load==1, then 
- * the in value is loaded into the memory location specified by address 
+ * stored at the memory location specified by address. If load==1, then
+ * the in value is loaded into the memory location specified by address
  * (the loaded value will be emitted to out from the next time step onward).
  */
 
@@ -15,5 +15,16 @@ CHIP RAM64 {
     OUT out[16];
 
     PARTS:
-    // Put your code here:
+    // 6 ビットのアドレスが xxxyyy だとすると上位の xxx は RAM8 を一つ選択するために用いる
+    DMux8Way(in=load, sel=address[3..5], a=loada, b=loadb, c=loadc, d=loadd, e=loade, f=loadf, g=loadg, h=loadh);
+    // 6 ビットアドレス下位の yyy は RAM8 から特定のレジスタを選択するために用いる
+    RAM8(in=in, load=loada, address=address[0..2], out=outa);
+    RAM8(in=in, load=loadb, address=address[0..2], out=outb);
+    RAM8(in=in, load=loadc, address=address[0..2], out=outc);
+    RAM8(in=in, load=loadd, address=address[0..2], out=outd);
+    RAM8(in=in, load=loade, address=address[0..2], out=oute);
+    RAM8(in=in, load=loadf, address=address[0..2], out=outf);
+    RAM8(in=in, load=loadg, address=address[0..2], out=outg);
+    RAM8(in=in, load=loadh, address=address[0..2], out=outh);
+    Mux8Way16(a=outa, b=outb, c=outc, d=outd, e=oute, f=outf, g=outg, h=outh, sel=address[3..5], out=out);
 }

--- a/projects/03/a/RAM8.hdl
+++ b/projects/03/a/RAM8.hdl
@@ -5,15 +5,27 @@
 
 /**
  * Memory of 8 registers, each 16 bit-wide. Out holds the value
- * stored at the memory location specified by address. If load==1, then 
- * the in value is loaded into the memory location specified by address 
+ * stored at the memory location specified by address. If load==1, then
+ * the in value is loaded into the memory location specified by address
  * (the loaded value will be emitted to out from the next time step onward).
  */
 
 CHIP RAM8 {
+    // 3 ビットのアドレスで 8 通りまで表現できる
     IN in[16], load, address[3];
     OUT out[16];
 
     PARTS:
-    // Put your code here:
+    // write の実装（load が 1 の address に書き込む）
+    DMux8Way(in=load, sel=address, a=loada, b=loadb, c=loadc, d=loadd, e=loade, f=loadf, g=loadg, h=loadh);
+    Register(in=in, load=loada, out=r1);
+    Register(in=in, load=loadb, out=r2);
+    Register(in=in, load=loadc, out=r3);
+    Register(in=in, load=loadd, out=r4);
+    Register(in=in, load=loade, out=r5);
+    Register(in=in, load=loadf, out=r6);
+    Register(in=in, load=loadg, out=r7);
+    Register(in=in, load=loadh, out=r8);
+    // read の実装（上の Register の out も関係あるけど）
+    Mux8Way16(a=r1, b=r2, c=r3, d=r4, e=r5, f=r6, g=r7, h=r8, sel=address, out=out);
 }

--- a/projects/03/a/RAM8.hdl
+++ b/projects/03/a/RAM8.hdl
@@ -19,7 +19,7 @@ CHIP RAM8 {
     // address で指定された Register に対して、load が 0 なら読み込み、1 なら書き込みを行う
     // write のための address 指定
     DMux8Way(in=load, sel=address, a=loada, b=loadb, c=loadc, d=loadd, e=loade, f=loadf, g=loadg, h=loadh);
-    // Register 自体は load で指定される read/write に関わらず、値を出力する（write なら新しく書き込まれた値を出力）
+    // Register 自体は load で指定される read/write に関わらず、値を出力する（~write なら新しく書き込まれた値を出力~ write で新しい値が出力されるのは書き込みの次のクロック周期から）
     Register(in=in, load=loada, out=r1);
     Register(in=in, load=loadb, out=r2);
     Register(in=in, load=loadc, out=r3);

--- a/projects/03/a/RAM8.hdl
+++ b/projects/03/a/RAM8.hdl
@@ -16,8 +16,10 @@ CHIP RAM8 {
     OUT out[16];
 
     PARTS:
-    // write の実装（load が 1 の address に書き込む）
+    // address で指定された Register に対して、load が 0 なら読み込み、1 なら書き込みを行う
+    // write のための address 指定
     DMux8Way(in=load, sel=address, a=loada, b=loadb, c=loadc, d=loadd, e=loade, f=loadf, g=loadg, h=loadh);
+    // Register 自体は load で指定される read/write に関わらず、値を出力する（write なら新しく書き込まれた値を出力）
     Register(in=in, load=loada, out=r1);
     Register(in=in, load=loadb, out=r2);
     Register(in=in, load=loadc, out=r3);
@@ -26,6 +28,6 @@ CHIP RAM8 {
     Register(in=in, load=loadf, out=r6);
     Register(in=in, load=loadg, out=r7);
     Register(in=in, load=loadh, out=r8);
-    // read の実装（上の Register の out も関係あるけど）
+    // read のための address 指定
     Mux8Way16(a=r1, b=r2, c=r3, d=r4, e=r5, f=r6, g=r7, h=r8, sel=address, out=out);
 }

--- a/projects/03/a/Register.hdl
+++ b/projects/03/a/Register.hdl
@@ -14,5 +14,22 @@ CHIP Register {
     OUT out[16];
 
     PARTS:
-    // Put your code here:
+    // 1 ビットレジスタを n 個並べてレジスタの load 入力を
+    // 全ての 1 ビットレジスタへの load 入力に接続すれば OK
+    Bit(in=in[0], load=load, out=out[0]);
+    Bit(in=in[1], load=load, out=out[1]);
+    Bit(in=in[2], load=load, out=out[2]);
+    Bit(in=in[3], load=load, out=out[3]);
+    Bit(in=in[4], load=load, out=out[4]);
+    Bit(in=in[5], load=load, out=out[5]);
+    Bit(in=in[6], load=load, out=out[6]);
+    Bit(in=in[7], load=load, out=out[7]);
+    Bit(in=in[8], load=load, out=out[8]);
+    Bit(in=in[9], load=load, out=out[9]);
+    Bit(in=in[10], load=load, out=out[10]);
+    Bit(in=in[11], load=load, out=out[11]);
+    Bit(in=in[12], load=load, out=out[12]);
+    Bit(in=in[13], load=load, out=out[13]);
+    Bit(in=in[14], load=load, out=out[14]);
+    Bit(in=in[15], load=load, out=out[15]);
 }

--- a/projects/03/b/RAM16K.hdl
+++ b/projects/03/b/RAM16K.hdl
@@ -5,8 +5,8 @@
 
 /**
  * Memory of 16K registers, each 16 bit-wide. Out holds the value
- * stored at the memory location specified by address. If load==1, then 
- * the in value is loaded into the memory location specified by address 
+ * stored at the memory location specified by address. If load==1, then
+ * the in value is loaded into the memory location specified by address
  * (the loaded value will be emitted to out from the next time step onward).
  */
 
@@ -15,5 +15,11 @@ CHIP RAM16K {
     OUT out[16];
 
     PARTS:
-    // Put your code here:
+    // 上位 2 ビットはどの RAM を選択するかに使われる（4K -> 16K なら RAM4K を 4 つ並べれば OK）
+    DMux4Way(in=load, sel=address[12..13], a=loada, b=loadb, c=loadc, d=loadd);
+    RAM4K(in=in, load=loada, address=address[0..11], out=outa);
+    RAM4K(in=in, load=loadb, address=address[0..11], out=outb);
+    RAM4K(in=in, load=loadc, address=address[0..11], out=outc);
+    RAM4K(in=in, load=loadd, address=address[0..11], out=outd);
+    Mux4Way16(a=outa, b=outb, c=outc, d=outd, sel=address[12..13], out=out);
 }

--- a/projects/03/b/RAM4K.hdl
+++ b/projects/03/b/RAM4K.hdl
@@ -5,8 +5,8 @@
 
 /**
  * Memory of 4K registers, each 16 bit-wide. Out holds the value
- * stored at the memory location specified by address. If load==1, then 
- * the in value is loaded into the memory location specified by address 
+ * stored at the memory location specified by address. If load==1, then
+ * the in value is loaded into the memory location specified by address
  * (the loaded value will be emitted to out from the next time step onward).
  */
 
@@ -15,5 +15,15 @@ CHIP RAM4K {
     OUT out[16];
 
     PARTS:
-    // Put your code here:
+    // 上位 3 ビットはどの RAM を選択するかに使われる
+    DMux8Way(in=load, sel=address[9..11], a=loada, b=loadb, c=loadc, d=loadd, e=loade, f=loadf, g=loadg, h=loadh);
+    RAM512(in=in, load=loada, address=address[0..8], out=outa);
+    RAM512(in=in, load=loadb, address=address[0..8], out=outb);
+    RAM512(in=in, load=loadc, address=address[0..8], out=outc);
+    RAM512(in=in, load=loadd, address=address[0..8], out=outd);
+    RAM512(in=in, load=loade, address=address[0..8], out=oute);
+    RAM512(in=in, load=loadf, address=address[0..8], out=outf);
+    RAM512(in=in, load=loadg, address=address[0..8], out=outg);
+    RAM512(in=in, load=loadh, address=address[0..8], out=outh);
+    Mux8Way16(a=outa, b=outb, c=outc, d=outd, e=oute, f=outf, g=outg, h=outh, sel=address[9..11], out=out);
 }

--- a/projects/03/b/RAM512.hdl
+++ b/projects/03/b/RAM512.hdl
@@ -1,12 +1,12 @@
-// This file is part of the materials accompanying the book 
-// "The Elements of Computing Systems" by Nisan and Schocken, 
+// This file is part of the materials accompanying the book
+// "The Elements of Computing Systems" by Nisan and Schocken,
 // MIT Press. Book site: www.idc.ac.il/tecs
 // File name: projects/03/b/RAM512.hdl
 
 /**
  * Memory of 512 registers, each 16 bit-wide. Out holds the value
- * stored at the memory location specified by address. If load==1, then 
- * the in value is loaded into the memory location specified by address 
+ * stored at the memory location specified by address. If load==1, then
+ * the in value is loaded into the memory location specified by address
  * (the loaded value will be emitted to out from the next time step onward).
  */
 
@@ -15,5 +15,16 @@ CHIP RAM512 {
     OUT out[16];
 
     PARTS:
-    // Put your code here:
+    // 9 ビットのアドレスが xxxyyyzzz だとすると上位の xxx は RAM64 を一つ選択するために用いる
+    DMux8Way(in=load, sel=address[6..8], a=loada, b=loadb, c=loadc, d=loadd, e=loade, f=loadf, g=loadg, h=loadh);
+    // 9 ビットアドレス下位の yyyzzz（6 ビット）は RAM64 の入力に使う
+    RAM64(in=in, load=loada, address=address[0..5], out=outa);
+    RAM64(in=in, load=loadb, address=address[0..5], out=outb);
+    RAM64(in=in, load=loadc, address=address[0..5], out=outc);
+    RAM64(in=in, load=loadd, address=address[0..5], out=outd);
+    RAM64(in=in, load=loade, address=address[0..5], out=oute);
+    RAM64(in=in, load=loadf, address=address[0..5], out=outf);
+    RAM64(in=in, load=loadg, address=address[0..5], out=outg);
+    RAM64(in=in, load=loadh, address=address[0..5], out=outh);
+    Mux8Way16(a=outa, b=outb, c=outc, d=outd, e=oute, f=outf, g=outg, h=outh, sel=address[6..8], out=out);
 }


### PR DESCRIPTION
## Overview

実装済みのフリップフロップや前章までの回路を使ってレジスタやメモリやカウンタの実装をした。

レジスタやメモリなどようやく聞き覚えのある単語が出てきてワイ歓喜。

PC（カウンタ）の実装漏れてたので追加 👉 a0d59f85dbf365e0601316c3d9c4af9dfee7adbe

## Note

アドレスはレジスタを一意に指定する必要がある。

レジスタは 1 ビットレジスタを n 個並べて作る（今回は16）。
メモリはレジスタを並べて作り、より大きなサイズのメモリは一段階小さなサイズのメモリを再帰的に呼び出して実装する。（DMux と Mux の間に挟み込む形で、DMux と Mux に address を食わせてどのメモリを load するかを指定する）

## 参考

- https://github.com/ikenox/nand2tetris/tree/master/03
- https://github.com/havivha/Nand2Tetris/tree/master/03
- https://github.com/xctom/Nand2Tetris/tree/master/projects/03
- https://github.com/sake92/nand2tetris/tree/master/projects/03
- https://github.com/ohbarye/nand2tetris/tree/master/projects/03